### PR TITLE
Fixes MultipleObjectsReturned error on get_or_404_check_course

### DIFF
--- a/sga/models.py
+++ b/sga/models.py
@@ -5,10 +5,8 @@ from datetime import datetime
 
 import pytz
 from django.contrib.auth.models import User
-from django.core.exceptions import PermissionDenied
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
-from django.shortcuts import get_object_or_404
 
 from sga.backend.files import student_submission_file_path, grader_submission_file_path
 from sga.backend.validators import validate_file_extension, validate_file_size
@@ -35,27 +33,7 @@ class TimeStampedModel(models.Model):
         abstract = True
 
 
-class CourseModel(TimeStampedModel):
-    """
-    Base model for models relating to the course to allow authentication checks
-    """
-    @classmethod
-    def get_or_404_check_course(cls, course_id, **kwargs):
-        """
-        Runs a get_or_404 on the object class with kwargs. If an object is returned, checks if the object is
-        part of the course with id course_id.
-        """
-        obj = get_object_or_404(cls, **kwargs)
-        # Cast to string because course_id is passed as str from view
-        if str(obj.course_id) != str(course_id):
-            raise PermissionDenied()
-        return obj
-
-    class Meta:
-        abstract = True
-
-
-class Grader(CourseModel):
+class Grader(TimeStampedModel):
     """
     Grader model (intermediate between Course and User)
     """
@@ -104,7 +82,7 @@ class Grader(CourseModel):
         unique_together = (("user", "course"),)
 
 
-class Student(CourseModel):
+class Student(TimeStampedModel):
     """
     Student model (intermediate between Course and User)
     """
@@ -161,7 +139,7 @@ class Course(TimeStampedModel):
         ).count()
 
 
-class Assignment(CourseModel):
+class Assignment(TimeStampedModel):
     """
     Assignment model
     """

--- a/sga/tests/models_test.py
+++ b/sga/tests/models_test.py
@@ -4,9 +4,7 @@ Test end to end django models.
 from datetime import datetime
 from time import sleep
 
-from django.core.exceptions import PermissionDenied
-
-from sga.models import Course, Submission, Grader
+from sga.models import Course, Submission
 from sga.tests.common import SGATestCase
 
 
@@ -257,11 +255,3 @@ class TestModels(SGATestCase):
         self.assertEqual(submission.grade_display(), "(Not Graded)")
         submission.update(grade=70)
         self.assertEqual(submission.grade_display(), "70/100 (70%)")
-
-    def test_course_get_or_404_check_course(self):
-        """
-        Tests the .get_or_404_check_course() method on CourseModel
-        """
-        grader = self.get_test_grader()
-        self.assertEqual(Grader.get_or_404_check_course(grader.course_id, id=grader.id), grader)
-        self.assertRaises(PermissionDenied, Grader.get_or_404_check_course, grader.course_id + 1, id=grader.id)

--- a/sga/views.py
+++ b/sga/views.py
@@ -65,7 +65,7 @@ def view_submission_as_student(request, course_id, assignment_id):
     """
     View submission (for student)
     """
-    assignment = Assignment.get_or_404_check_course(course_id, id=assignment_id)
+    assignment = get_object_or_404(Assignment, course_id=course_id, id=assignment_id)
     submission, _ = Submission.objects.get_or_create(student=request.user, assignment=assignment)
     if request.method == "POST":
         submission_form = StudentAssignmentSubmissionForm(request.POST, request.FILES, instance=submission)
@@ -90,11 +90,11 @@ def view_submission_as_staff(request, course_id, assignment_id, student_user_id)
     """
     View submission (for staff)
     """
-    student = Student.get_or_404_check_course(course_id, user_id=student_user_id, deleted=False)
+    student = get_object_or_404(Student, course_id=course_id, user_id=student_user_id, deleted=False)
     # Disallow if current user is not admin or this grader
     if request.role == Roles.grader and student.grader is not None and student.grader.user != request.user:
         return HttpResponseForbidden()
-    assignment = Assignment.get_or_404_check_course(course_id, id=assignment_id)
+    assignment = get_object_or_404(Assignment, course_id=course_id, id=assignment_id)
     submission, _ = Submission.objects.get_or_create(student=student.user, assignment=assignment)
     next_not_graded_submission = Submission.objects.filter(
         assignment=assignment,
@@ -211,7 +211,7 @@ def view_student(request, course_id, student_user_id):
     View student
     """
     course = get_object_or_404(Course, id=course_id)
-    student = Student.get_or_404_check_course(course_id, user_id=student_user_id, deleted=False)
+    student = get_object_or_404(Student, course_id=course_id, user_id=student_user_id, deleted=False)
     if request.method == "POST" and request.role == Roles.admin:
         assign_grader_form = AssignGraderToStudentForm(request.POST, instance=student)
         if assign_grader_form.is_valid():
@@ -237,7 +237,7 @@ def view_grader(request, course_id, grader_user_id):
     View grader
     """
     course = get_object_or_404(Course, id=course_id)
-    grader = Grader.get_or_404_check_course(course_id, user_id=grader_user_id)
+    grader = get_object_or_404(Grader, course_id=course_id, user_id=grader_user_id)
     # Disallow if current user is not admin or this grader
     if request.role == Roles.grader and grader.user != request.user:
         return HttpResponseForbidden()
@@ -276,7 +276,7 @@ def view_assignment(request, course_id, assignment_id):
     """
     View assignment
     """
-    assignment = Assignment.get_or_404_check_course(course_id, id=assignment_id)
+    assignment = get_object_or_404(Assignment, course_id=course_id, id=assignment_id)
     submitted_submissions = get_submitted_submissions(request, assignment)
     not_graded_submissions = submitted_submissions.exclude(graded=True)
     if request.role == Roles.admin:
@@ -302,7 +302,7 @@ def download_all_submissions(request, course_id, assignment_id, not_graded_only=
     """
     Generate and serve zip file with submission files
     """
-    assignment = Assignment.get_or_404_check_course(course_id, id=assignment_id)
+    assignment = get_object_or_404(Assignment, course_id=course_id, id=assignment_id)
     submissions = get_submitted_submissions(request, assignment, not_graded_only=not_graded_only)
     course = Course.objects.get(id=course_id)
     full_zipname = "{course_edx_id} - {zipname}".format(course_edx_id=course.edx_id, zipname=zipname)
@@ -329,7 +329,7 @@ def change_grader_to_student(request, course_id, grader_user_id):  # pylint: dis
     """
     Change grader to student
     """
-    grader = Grader.get_or_404_check_course(course_id, user_id=grader_user_id)
+    grader = get_object_or_404(Grader, course_id=course_id, user_id=grader_user_id)
     student, _ = Student.objects.update_or_create(
         course_id=course_id,
         user_id=grader_user_id,
@@ -345,7 +345,7 @@ def change_student_to_grader(request, course_id, student_user_id):  # pylint: di
     """
     Change student to grader
     """
-    student = Student.get_or_404_check_course(course_id, user_id=student_user_id)
+    student = get_object_or_404(Student, course_id=course_id, user_id=student_user_id)
     grader = Grader.objects.create(
         user=student.user,
         course=student.course
@@ -360,8 +360,8 @@ def unsubmit_submission(request, course_id, assignment_id, student_user_id):  # 
     """
     Unsubmits a submission
     """
-    assignment = Assignment.get_or_404_check_course(course_id, id=assignment_id)
-    student = Student.get_or_404_check_course(course_id, user_id=student_user_id)
+    assignment = get_object_or_404(Assignment, course_id=course_id, id=assignment_id)
+    student = get_object_or_404(Student, course_id=course_id, user_id=student_user_id)
     submission, _ = Submission.objects.get_or_create(student=student.user, assignment=assignment)
     submission.submitted = False
     submission.graded = False
@@ -380,7 +380,7 @@ def unassign_grader(request, course_id, student_user_id):  # pylint: disable=unu
     """
     Unassign a grader from a student
     """
-    student = Student.get_or_404_check_course(course_id, user_id=student_user_id)
+    student = get_object_or_404(Student, course_id=course_id, user_id=student_user_id)
     student.update(grader=None)
     return redirect("view_student", course_id=student.course.id, student_user_id=student_user_id)
 
@@ -391,7 +391,7 @@ def unassign_student(request, course_id, grader_user_id, student_user_id):  # py
     """
     Unassign a student from a grader
     """
-    grader = Grader.get_or_404_check_course(course_id, user_id=grader_user_id)
+    grader = get_object_or_404(Grader, course_id=course_id, user_id=grader_user_id)
     student = get_object_or_404(Student, user_id=student_user_id, grader=grader)
     student.update(grader=None)
     return redirect("view_grader", course_id=course_id, grader_user_id=grader_user_id)


### PR DESCRIPTION
#### What are the relevant tickets?
#49 

#### What's this PR do?
A 500 error was caused by cls.get_or_404_check_course() because it relied on get_object_or_404() and multiple objects were returned.  The solution was to remove this method and just include course_id as a parameter in the get_object_or_404() calls.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

