### PR TITLE
Fixed has no grader filter

### DIFF
--- a/sga/static/js/dataTables.filters.js
+++ b/sga/static/js/dataTables.filters.js
@@ -1,13 +1,10 @@
 function filterReset(table) {
-    console.log("hi");
-    console.log($(this));
-    console.log("hi");
     table.search("").columns().search("").draw();
 }
 
 function filterHasNoGrader(table, column) {
     filterReset(table);
-    table.columns(column).search("^(No Grader)$").draw();
+    table.columns(column).search("(No Grader)").draw();
 }
 
 function filterHasGrader(table, column) {


### PR DESCRIPTION
#### What are the relevant tickets?
#53 

#### What's this PR do?
Fixes the "Has No Grader" filter.  The dataTables.search() function was expecting a string input but a regex input was provided.

#### Where should the reviewer start?

#### How should this be manually tested?

#### Any background context you want to provide?

#### Screenshots (if appropriate)

#### What GIF best describes this PR or how it makes you feel?

